### PR TITLE
Change Result Type so that assignment is more flexible

### DIFF
--- a/src/main/kotlin/com/danneu/result/Result.kt
+++ b/src/main/kotlin/com/danneu/result/Result.kt
@@ -20,12 +20,12 @@ fun <V, V2, E> Result<V, E>.flatMap(transformValue: (V) -> Result<V2, E>): Resul
     is Result.Ok<V> ->
         transformValue(value)
     is Result.Err<E> ->
-        Result.Err<E>(error)
+        this
 }
 
 fun <V, E, E2> Result<V, E>.flatMapError(transformError: (E) -> Result<V, E2>): Result<V, E2> = when (this) {
     is Result.Ok<V> ->
-        Result.Ok<V>(value)
+        this
     is Result.Err<E> ->
         transformError(error)
 }
@@ -42,12 +42,12 @@ sealed class Result <out V, out E> {
         is Ok ->
             Ok<V2>(transformValue(value))
         is Err ->
-            Err<E>(error)
+            this
     }
 
     fun <E2> mapError(transformError: (E) -> E2): Result<V, E2> = when (this) {
         is Ok ->
-            Ok<V>(value)
+            this
         is Err ->
             Err<E2>(transformError(error))
     }
@@ -94,7 +94,7 @@ sealed class Result <out V, out E> {
                         it.value
                     is Err<E> ->
                         // Short-circuit
-                        return err(it.error)
+                        return it
                 }
             })
         }

--- a/src/main/kotlin/com/danneu/result/Result.kt
+++ b/src/main/kotlin/com/danneu/result/Result.kt
@@ -3,30 +3,30 @@ package com.danneu.result
 class UnwrapException(message: String) : Exception(message)
 
 fun <V, E> Result<V, E>.getOrElse(default: V) = when (this) {
-    is Result.Ok<V, E> ->
+    is Result.Ok<V> ->
         value
-    is Result.Err<V, E> ->
+    is Result.Err<E> ->
         default
 }
 
 fun <V, E> Result<V, E>.getOrElse(transformError: (E) -> V) = when (this) {
-    is Result.Ok<V, E> ->
+    is Result.Ok<V> ->
         value
-    is Result.Err<V, E> ->
+    is Result.Err<E> ->
         transformError(error)
 }
 
 fun <V, V2, E> Result<V, E>.flatMap(transformValue: (V) -> Result<V2, E>): Result<V2, E> = when (this) {
-    is Result.Ok<V, E> ->
+    is Result.Ok<V> ->
         transformValue(value)
-    is Result.Err<V, E> ->
-        Result.Err<V2, E>(error)
+    is Result.Err<E> ->
+        Result.Err<E>(error)
 }
 
 fun <V, E, E2> Result<V, E>.flatMapError(transformError: (E) -> Result<V, E2>): Result<V, E2> = when (this) {
-    is Result.Ok<V, E> ->
-        Result.Ok<V, E2>(value)
-    is Result.Err<V, E> ->
+    is Result.Ok<V> ->
+        Result.Ok<V>(value)
+    is Result.Err<E> ->
         transformError(error)
 }
 
@@ -40,16 +40,16 @@ sealed class Result <out V, out E> {
 
     fun <V2> map(transformValue: (V) -> V2): Result<V2, E> = when (this) {
         is Ok ->
-            Ok<V2, E>(transformValue(value))
+            Ok<V2>(transformValue(value))
         is Err ->
-            Err<V2, E>(error)
+            Err<E>(error)
     }
 
     fun <E2> mapError(transformError: (E) -> E2): Result<V, E2> = when (this) {
         is Ok ->
-            Ok<V, E2>(value)
+            Ok<V>(value)
         is Err ->
-            Err<V, E2>(transformError(error))
+            Err<E2>(transformError(error))
     }
 
     fun <V2> fold(transformValue: (V) -> V2, transformError: (E) -> V2): V2 = when (this) {
@@ -59,29 +59,29 @@ sealed class Result <out V, out E> {
             transformError(error)
     }
 
-    class Ok <out V, out E> internal constructor (val value: V): Result<V, E>() {
+    class Ok <out V> internal constructor (val value: V): Result<V, Nothing>() {
         override fun toString() = "Result.Ok($value)"
         override fun hashCode() = value?.hashCode() ?: 0
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            return other is Ok<*, *> && value == other.value
+            return other is Ok<*> && value == other.value
         }
     }
 
-    class Err <out V, out E> internal constructor (val error: E): Result<V, E>() {
+    class Err <out E> internal constructor (val error: E): Result<Nothing, E>() {
         override fun toString() = "Result.Err($error)"
         override fun hashCode() = error?.hashCode() ?: 0
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            return other is Err<*, *> && error == other.error
+            return other is Err<*> && error == other.error
         }
     }
 
     companion object {
         // FACTORIES
 
-        fun <V> ok (value: V): Result<V, Nothing> = Result.Ok(value)
-        fun <E> err (error: E): Result<Nothing, E> = Result.Err(error)
+        fun <V> ok (value: V): Result.Ok<V> = Result.Ok(value)
+        fun <E> err (error: E): Result.Err<E> = Result.Err(error)
 
         // MANY
 
@@ -90,9 +90,9 @@ sealed class Result <out V, out E> {
         fun <V, E> all (results: Iterable<Result<V, E>>): Result<List<V>, E> {
             return ok(results.map {
                 when (it) {
-                    is Ok<V, E> ->
+                    is Ok<V> ->
                         it.value
-                    is Err<V, E> ->
+                    is Err<E> ->
                         // Short-circuit
                         return err(it.error)
                 }

--- a/src/test/kotlin/com.danneu.result/ResultTests.kt
+++ b/src/test/kotlin/com.danneu.result/ResultTests.kt
@@ -37,11 +37,11 @@ class ResultTests {
     @Test
     fun testMap() {
         assertEquals(
-            Result.Ok<Int, String>(3),
+            Result.Ok<Int>(3),
             Result.ok(1).map { it + 1 }.map { it + 1 }
         )
         assertEquals(
-            Result.Err<Int, String>("failure"),
+            Result.Err<String>("failure"),
             Result.err("failure").map { n: Int -> n + 1 }.map { n: Int -> n + 1 }
         )
     }
@@ -50,12 +50,12 @@ class ResultTests {
     fun testFlatMap() {
         assertEquals(
             "flatMap transitions ok result",
-            Result.Ok<Int, String>(3),
+            Result.Ok<Int>(3),
             Result.ok(1).flatMap { Result.ok(2) }.flatMap { Result.ok(3) }
         )
         assertEquals(
             "err result stops flatMap",
-            Result.Err<Int, String>("failure"),
+            Result.Err<String>("failure"),
             Result.ok(1).flatMap { Result.err("failure") }.flatMap { Result.ok(3) }
         )
     }
@@ -64,11 +64,11 @@ class ResultTests {
     fun testFlatMapError() {
         assertEquals(
             "ok result stops flatMapError",
-            Result.Ok<Int, String>(1),
+            Result.Ok<Int>(1),
             Result.ok(1).flatMapError { Result.ok(2) }
         )
         assertEquals(
-            Result.Ok<Int, String>(2),
+            Result.Ok<Int>(2),
             Result.err("failure").flatMapError { Result.ok(2) }
         )
     }
@@ -77,12 +77,12 @@ class ResultTests {
     fun testMapError() {
         assertEquals(
             "mapError cannot transition ok result",
-            Result.Ok<Int, String>(1),
+            Result.Ok<Int>(1),
             Result.ok(1).mapError { "failure" }
         )
         assertEquals(
             "mapError transforms err",
-            Result.Err<Int, String>("failure-mapped"),
+            Result.Err<String>("failure-mapped"),
             Result.err("failure").mapError { it + "-mapped" }
         )
     }
@@ -91,13 +91,13 @@ class ResultTests {
     fun testAll() {
         assertEquals(
             "Result.all combines ok values",
-            Result.Ok<List<Int>, String>(listOf(1, 2, 3)),
+            Result.Ok<List<Int>>(listOf(1, 2, 3)),
             Result.all(Result.ok(1), Result.ok(2), Result.ok(3))
         )
 
         assertEquals(
             "Result.all becomes first err",
-            Result.Err<List<Int>, String>("a"),
+            Result.Err<String>("a"),
             Result.all(
                 Result.ok(1), Result.err("a"),
                 Result.ok(2), Result.err("b"),
@@ -126,5 +126,19 @@ class ResultTests {
         assertNotEquals(Result.ok(42), Result.err("failure"))
         assertNotEquals(Result.ok(42), Result.ok(-42))
         assertNotEquals(Result.err("failure A"), Result.err("failure B"))
+    }
+
+    @Test
+    fun testAssignResultOk() {
+        val ok: Result.Ok<String> = Result.ok("ok")
+        val result: Result<String, Float> = ok
+        val result2: Result<String, Int> = ok
+    }
+
+    @Test
+    fun testAssignResultErr() {
+        val err: Result.Err<String> = Result.err("err")
+        val result: Result<Float, String> = err
+        val result2: Result<Int, String> = err
     }
 }


### PR DESCRIPTION
I've found that when using this library I often want to be able to do something like so: (Note that the following code would be better handled by using the `map` function in the result library. That being said this hopefully illustrates the point) 
```
fun foo(): Result<Int, String> {
  val result = bar()
  return when(result) {
    is Ok -> Result.ok(transform(value))
    is Err -> result
  } 
}

fun bar(): Result<Float, String> {
...
}
```
The problem is in the Err line because Result.Err<Float, String> is not assignable to Result<Int, String>. But the value parameter of Result.Err is irrelevant, because we know we have an error. Therefore it is always safe to assign a Result.Err<V1,E> to a Result.Err<V2,E>. The type system just doesn't allow it when defined like so.

The key change this PR makes is to define Ok and Err as so:
`class Ok <out V> internal constructor (val value: V): Result<V, Nothing>()`
`class Err <out E> internal constructor (val error: E): Result<Nothing, E>()`

Now Err and Ok only have one type parameter each, and the above assignments work. It also improves the built in library somewhat by not requiring unwrapping and rewrapping of Results in certain cases.

